### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ datasets
 #deepspeed
 hf-transfer
 peft
-protobuf==5.29.0
+protobuf>=3.12.2,<5.28.0
 tensorboard
 transformers>=4.46.0
 trl==0.15.2


### PR DESCRIPTION

<img width="1469" alt="Screenshot_2025-04-01_at_3 57 15_AM" src="https://github.com/user-attachments/assets/900624a6-4ac2-4bdb-b852-81beeaa5e10e" />

Fix: Pin protobuf version to <5.28.0 to avoid hivemind compatibility error

fixes a dependency conflict between `protobuf` and `hivemind`.

Currently, `requirements.txt` pins `protobuf==5.29.0`, which is a yanked version on PyPI and is **incompatible** with `hivemind==1.2.0.dev0`.

Reference

https://github.com/protocolbuffers/protobuf/issues/19430#issuecomment-2518458119