### PR TITLE
wait until api key is activated

### DIFF
--- a/modal-login/app/api/get-api-key-status/route.ts
+++ b/modal-login/app/api/get-api-key-status/route.ts
@@ -12,7 +12,6 @@ export async function GET(request: Request) {
 
   try {
     const key = getLatestApiKey(orgId);
-    console.log({ key });
     return new NextResponse(`${key?.activated ? "activated" : "pending"}`, {
       status: 200,
     });

--- a/modal-login/app/api/get-api-key-status/route.ts
+++ b/modal-login/app/api/get-api-key-status/route.ts
@@ -1,0 +1,23 @@
+import { getLatestApiKey } from "@/app/db";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { orgId } = Object.fromEntries(new URL(request.url).searchParams);
+  if (!orgId) {
+    return NextResponse.json(
+      { json: { error: "bad request" } },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const key = getLatestApiKey(orgId);
+    console.log({ key });
+    return new NextResponse(`${key?.activated ? "activated" : "pending"}`, {
+      status: 200,
+    });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ json: { error: "error" } }, { status: 500 });
+  }
+}

--- a/modal-login/app/api/get-api-key/route.ts
+++ b/modal-login/app/api/get-api-key/route.ts
@@ -1,21 +1,13 @@
-import { upsertUser, getLatestApiKey } from "@/app/db";
+import { upsertUser } from "@/app/db";
 import crypto from "crypto";
 import { NextResponse } from "next/server";
-import { TurnkeyApiTypes, TSignedRequest } from "@turnkey/http";
+import { TSignedRequest } from "@turnkey/http";
 
-/**
- * Existing API keys will be reused if they have at least this much
- * time until expiration. If not, a new key will be created.
- */
-const MIN_KEY_DURATION_REMAINING_MS = 1000 * 60 * 60 * 24 * 62; // 62 days
-
-const TURNKEY_BASE_URL = "https://api.turnkey.com";
 const ALCHEMY_BASE_URL = "https://api.g.alchemy.com";
 
 export async function POST(request: Request) {
   const body: {
     whoamiStamp: TSignedRequest;
-    getOrganizationStamp: TSignedRequest;
   } = await request.json().catch((err) => {
     console.error(err);
     return NextResponse.json(
@@ -25,39 +17,22 @@ export async function POST(request: Request) {
   });
 
   try {
-    const [tkResp, alchemyResp] = await Promise.all([
-      fetch(`${TURNKEY_BASE_URL}/public/v1/query/get_organization`, {
-        method: "POST",
-        body: body.getOrganizationStamp.body,
-        headers: {
-          "X-Stamp": body.getOrganizationStamp.stamp.stampHeaderValue,
-          "Content-Type": "application/json",
-        },
+    const alchemyResp = await fetch(`${ALCHEMY_BASE_URL}/signer/v1/whoami`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        stampedRequest: body.whoamiStamp,
       }),
-      fetch(`${ALCHEMY_BASE_URL}/signer/v1/whoami`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify({
-          stampedRequest: body.whoamiStamp,
-        }),
-      }),
-    ]);
+    });
 
-    if (!tkResp.ok) {
-      console.error(await tkResp.text());
-      throw new Error("Turnkey getOrganization request failed");
-    }
     if (!alchemyResp.ok) {
       console.error(await alchemyResp.text());
       throw new Error("Alchemy whoami request failed");
     }
-
-    const orgData: TurnkeyApiTypes["v1GetOrganizationResponse"]["organizationData"] =
-      (await tkResp.json()).organizationData;
 
     const userData: {
       userId: string;
@@ -65,46 +40,6 @@ export async function POST(request: Request) {
       address: string;
       email?: string; // Only exists if using email auth flow
     } = await alchemyResp.json();
-
-    const existingApiKeys = orgData.users
-      ?.find((u) => u.userId === userData.userId)
-      ?.apiKeys.filter(
-        (it) =>
-          // Assuming the client is naming API keys with "server-signer" prefix.
-          it.apiKeyName.startsWith("server-signer") &&
-          // The type of key that this server is generating.
-          it.credential.type === "CREDENTIAL_TYPE_API_KEY_P256",
-      )
-      .map((it) => ({
-        ...it,
-        // Calculate the expiresAt date based on the createdAt & expirationSeconds.
-        expiresAt: new Date(
-          (parseInt(it.createdAt.seconds) +
-            parseInt(it.expirationSeconds ?? "0")) *
-            1000,
-        ),
-      }))
-      .sort(
-        // Sort so the first API key in the array will be the longest lasting.
-        (a, b) => b.expiresAt.getTime() - a.expiresAt.getTime(),
-      );
-
-    const existingKey = existingApiKeys?.[0];
-      // Be sure the existing key exists in the db.
-    const existingKeyFromDb = getLatestApiKey(userData.orgId);
-    const existingKeyOk =
-      existingKey &&
-      existingKey.expiresAt.getTime() - Date.now() >
-        MIN_KEY_DURATION_REMAINING_MS &&
-        existingKeyFromDb?.publicKey === existingKey.credential.publicKey;
-
-    if (existingKeyOk) {
-      // Return the existing key.
-      return NextResponse.json(
-        { publicKey: existingKey.credential.publicKey, isNewKey: false },
-        { status: 200 },
-      );
-    }
 
     // Generate & store a key.
     const { publicKey, privateKey } = await generateKeyPair();
@@ -114,7 +49,7 @@ export async function POST(request: Request) {
       createdAt: new Date(),
     });
 
-    return NextResponse.json({ publicKey, isNewKey: true }, { status: 200 });
+    return NextResponse.json({ publicKey }, { status: 200 });
   } catch (err) {
     console.error(err);
     return NextResponse.json({ json: { error: "error" } }, { status: 500 });

--- a/modal-login/app/api/set-api-key-activated/route.ts
+++ b/modal-login/app/api/set-api-key-activated/route.ts
@@ -1,0 +1,23 @@
+import { setApiKeyActivated } from "@/app/db";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const body: {
+    orgId: string;
+    apiKey: string;
+  } = await request.json().catch((err) => {
+    console.error(err);
+    return NextResponse.json(
+      { json: { error: "bad request" } },
+      { status: 400 },
+    );
+  });
+
+  try {
+    setApiKeyActivated(body.orgId, body.apiKey);
+    return NextResponse.json({ activated: true }, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ json: { error: "error" } }, { status: 500 });
+  }
+}

--- a/modal-login/app/db.ts
+++ b/modal-login/app/db.ts
@@ -30,10 +30,13 @@ interface UserApiKey {
   publicKey: string;
   privateKey: string;
   createdAt: Date;
+  activated?: boolean;
 }
 
 /**
- * Upsert a user's data and their API key.
+ * Upsert a user's data and their API key. Removes all other users
+ * from the database file to avoid any potential conflicts when
+ * it's read by another process.
  *
  * Reads the current database from disk, updates the data,
  * and writes the new state back to disk.
@@ -47,6 +50,13 @@ export const upsertUser = (data: UserData, apiKey: UserApiKey) => {
   usersData[data.orgId] = data;
   const existingKeys = apiKeyData[data.orgId] || [];
   apiKeyData[data.orgId] = [...existingKeys, apiKey];
+
+  // Remove any users other than the current user.
+  Object.keys(usersData).forEach((key) => {
+    if (key !== data.orgId) {
+      delete usersData[key];
+    }
+  });
 
   // Write back to disk.
   writeJson(userDataPath, usersData);
@@ -68,4 +78,20 @@ export const getLatestApiKey = (orgId: string): UserApiKey | null => {
   const apiKeyData = readJson(apiKeyPath);
   const keys: UserApiKey[] = apiKeyData[orgId];
   return keys?.[keys.length - 1] ?? null;
+};
+
+export const setApiKeyActivated = (orgId: string, apiKey: string): void => {
+  const apiKeyData = readJson(apiKeyPath);
+  const keys: UserApiKey[] = apiKeyData[orgId];
+  const key = keys.find((k) => k.publicKey === apiKey);
+  if (!key) {
+    throw new Error("API key not found");
+  }
+  const updatedData = {
+    ...apiKeyData,
+    [orgId]: keys.map((k) =>
+      k.publicKey === apiKey ? { ...k, activated: true } : k,
+    ),
+  };
+  writeJson(apiKeyPath, updatedData);
 };

--- a/modal-login/app/layout.tsx
+++ b/modal-login/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
   // https://accountkit.alchemy.com/react/ssr#persisting-the-account-state
   const initialState = cookieToInitialState(
     config,
-    headers().get("cookie") ?? undefined
+    headers().get("cookie") ?? undefined,
   );
 
   return (

--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -77,6 +77,19 @@ if [ "$CONNECT_TO_TESTNET" = "True" ]; then
     ORG_ID=$(awk 'BEGIN { FS = "\"" } !/^[ \t]*[{}]/ { print $(NF - 1); exit }' modal-login/temp-data/userData.json)
     echo "ORG_ID set to: $ORG_ID"
 
+    # Wait until the API key is activated by the client
+    echo "Waiting for API key to become activated..."
+    while true; do
+        STATUS=$(curl -s "http://localhost:3000/api/get-api-key-status?orgId=$ORG_ID")
+        if [[ "$STATUS" == "activated" ]]; then
+            echo "API key is activated! Proceeding..."
+            break
+        else
+            echo "Waiting for API key to be activated..."
+            sleep 5
+        fi
+    done
+
     # Function to clean up the server process
     cleanup() {
         echo "Shutting down server..."


### PR DESCRIPTION
- remove logic handling re-use of existing api keys, since the desired behavior is now that a new api key is generated at each login
- when a user logs in, remove user data belonging to any other users from the db json file
- add new api routes for marking an api key as "activated" & checking its status
- update `run_rl_swarm` script to wait until api key is activated instead of only waiting for a user to be logged in
- show loading state on UI if user is logged in but api key hasn't been activated yet
- show an alert if `window.crypto.subtle` is not available so that it's obvious if a user is having issues due to the problem we discovered yesterday