### PR TITLE
fix(hivemind): increase DHT startup_timeout to avoid daemon failure

### DIFF
--- a/hivemind_exp/runner/gensyn/testnet_grpo_runner.py
+++ b/hivemind_exp/runner/gensyn/testnet_grpo_runner.py
@@ -36,7 +36,7 @@ class TestnetGRPORunner(GRPORunner):
     def setup_dht(self, grpo_args):
         initial_peers = grpo_args.initial_peers
 
-        dht = hivemind.DHT(start=True, **self._dht_kwargs(grpo_args))
+        dht = hivemind.DHT(start=True, startup_timeout=30, **self._dht_kwargs(grpo_args))
         logger.info(f"🐝 Joining swarm with initial_peers = {initial_peers}")
 
         peer_id = str(dht.peer_id)


### PR DESCRIPTION
This PR addresses an issue where the `hivemind.DHT` initialization was failing with the following error:
```
hivemind.p2p.p2p_daemon_bindings.utils.P2PDaemonError: Daemon failed to start in 15.0 seconds
```

To fix this, I increased the `startup_timeout` parameter in the `hivemind.DHT` constructor from the default 15 seconds to 30 seconds:

```python
dht = hivemind.DHT(start=True, startup_timeout=30, **self._dht_kwargs(grpo_args))
```

This allows more time for the daemon to start, particularly helpful in environments where startup might be delayed due to system load or network conditions.