### PR TITLE
Update run_rl_swarm.sh

### DIFF
--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -98,7 +98,16 @@ if [ "$CONNECT_TO_TESTNET" = "True" ]; then
     SERVER_PID=$!  # Store the process ID
     echo "Started server process: $SERVER_PID"
     sleep 5
-    open http://localhost:3000
+
+    # Open the URL based on available commands
+    if command -v xdg-open > /dev/null; then
+        xdg-open http://localhost:3000
+    elif command -v open > /dev/null; then
+        open http://localhost:3000
+    else
+        echo "Please open the following URL in your browser: http://localhost:3000"
+    fi
+
     cd ..
 
     echo_green ">> Waiting for modal userData.json to be created..."


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/88bddbd0-10e8-464e-ae50-b1438734d3fb)

There is no open command on Ubuntu servers. so it gets error and stops directly. That's why I added it.

   # Open the URL based on available commands
```
    if command -v xdg-open > /dev/null; then
        xdg-open http://localhost:3000
    elif command -v open > /dev/null; then
        open http://localhost:3000
    else
        echo "Please open the following URL in your browser: http://localhost:3000"
    fi
```