### PR TITLE
Fix run_rl_swarm.sh Script and Update package.json versions

### DIFF
--- a/modal-login/package.json
+++ b/modal-login/package.json
@@ -20,7 +20,7 @@
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",
-    "viem": "2.20.0",
+    "viem": "2.25.0",
     "wagmi": "2.12.7"
   },
   "devDependencies": {

--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -98,7 +98,7 @@ if [ "$CONNECT_TO_TESTNET" = "True" ]; then
     SERVER_PID=$!  # Store the process ID
     echo "Started server process: $SERVER_PID"
     sleep 5
-    open http://localhost:3000
+   # open http://localhost:3000
     cd ..
 
     echo_green ">> Waiting for modal userData.json to be created..."


### PR DESCRIPTION
### Fix run_rl_swarm.sh Script
The current bash script causes this Error at start:
```
./run_rl_swarm.sh: line 101: open: command not found
>> Shutting down trainer...
Terminated
```
commented out line 101: `open http://localhost:3000` by adding `#`, which was causing issues in some environments.

### Update package.json
Updated `viem` from version `2.20.0` to `2.25.0`