### PR TITLE
Update run_rl_swarm.sh

### DIFF
--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -149,7 +149,6 @@ if [ "$CONNECT_TO_TESTNET" = "True" ]; then
             sleep 5
         fi
     done
-fi
 
 pip_install() {
     pip install --disable-pip-version-check -q -r "$1"


### PR DESCRIPTION
After cloning the new repo, I got an error while starting the node; ```unexpected token `fi'```. This error was related to line 152 of the run_rl_swarm.sh file. Deleting ```fi```' on line 152 fixes it.