### PR TITLE
FIX: Key Error `question`

### DIFF
--- a/hivemind_exp/gsm8k/stage_merger.py
+++ b/hivemind_exp/gsm8k/stage_merger.py
@@ -6,11 +6,14 @@ def merge_stage1_question(outputs: Dict[str, Dict[str, Any]], log_tag=None):
     logger = logging.getLogger(f"{__name__}:{log_tag}")
 
     # TODO: Currently question+answer keeps getting replaced at every file. This is wasteful and can be optimized
-    # TODO: If an agents' answers more than once (or >1 answer from the same agent id hash), then current implementation will only keep the last seen in the loop. Should allow for multiple answers?
+    # TODO: If an agent answers more than once (or >1 answer from the same agent id hash), then current implementation will only keep the last seen in the loop. Should allow for multiple answers?
     merged = {"question": None, "answer": None, "agent_answers": {}}
     for agent, o in outputs.items():
-        if not merged.keys() == o.keys():
+        if not all(k in o for k in merged):
             logger.warning(f"Skipped malformed stage1 output from {agent}: {o}")
+            continue
+        if not isinstance(o["agent_answers"], dict):
+            logger.warning(f"Skipped malformed agent_answers from {agent}: {o}")
             continue
         merged["question"] = o["question"]
         merged["answer"] = o["answer"]
@@ -18,7 +21,7 @@ def merge_stage1_question(outputs: Dict[str, Dict[str, Any]], log_tag=None):
     # Fill with default values. TODO: Decide if this is a good choice.
     for agent in outputs:
         if agent not in merged["agent_answers"]:
-            merged["agent_answers"].update({agent: "No answer received..."})
+            merged["agent_answers"][agent] = "No answer received..."
     return merged
 
 
@@ -26,7 +29,7 @@ def merge_stage2_question(outputs: Dict[str, Dict[str, Any]], log_tag=None):
     logger = logging.getLogger(f"{__name__}:{log_tag}")
 
     # TODO: Currently question+answer keeps getting replaced at every file. This is wasteful and can be optimized
-    # TODO: If an agents' answers more than once (or >1 answer from the same agent id hash), then current implementation will only keep the last seen in the loop. Should allow for multiple answers?
+    # TODO: If an agent answers more than once (or >1 answer from the same agent id hash), then current implementation will only keep the last seen in the loop. Should allow for multiple answers?
     merged = {
         "question": None,
         "answer": None,
@@ -34,11 +37,12 @@ def merge_stage2_question(outputs: Dict[str, Dict[str, Any]], log_tag=None):
         "agent_opinion": {},
     }
     for agent, o in outputs.items():
-        if not merged.keys() == o.keys():
+        expected_keys = {"question", "answer", "stage2_prompt", "agent_opinion"}
+        if not expected_keys.issubset(o.keys()):
             logger.warning(f"Skipped malformed stage2 output from {agent}: {o}")
             continue
         if not isinstance(o["agent_opinion"], dict):
-            logger.warning(f"Skipped malformed stage2 output from {agent}: {o}")
+            logger.warning(f"Skipped malformed agent_opinion from {agent}: {o}")
             continue
         merged["question"] = o["question"]
         merged["answer"] = o["answer"]
@@ -47,5 +51,5 @@ def merge_stage2_question(outputs: Dict[str, Dict[str, Any]], log_tag=None):
     # Fill with default values. TODO: Decide if this is a good choice.
     for agent in outputs:
         if agent not in merged["agent_opinion"]:
-            merged["agent_opinion"].update({agent: "No feedback received..."})
+            merged["agent_opinion"][agent] = "No feedback received..."
     return merged


### PR DESCRIPTION
This patch fixes a KeyError: 'question' that occurs when malformed or incomplete outputs are returned by some peers during stage 1 and stage 2 of training. The updated logic adds validation checks and logging to safely skip over invalid entries while preserving expected behavior.