### PR TITLE
Fix TypeError: “NoneType” object is not iterable error in  reward function

### DIFF
--- a/hivemind_exp/gsm8k/stage3_rewards.py
+++ b/hivemind_exp/gsm8k/stage3_rewards.py
@@ -227,6 +227,15 @@ def final_correctness_reward_func(
     responses = [completion[0]["content"] for completion in completions]
     p = prompts[0][-1]["content"]
     extracted_responses = [extract_xml_final_answer(r) for r in responses]
+    
+    # Add null check
+    if answer is None or not extracted_responses:
+        return [0.0] * len(responses)
+    
+    # Make sure answer is iterable (convert to list if it's a single value)
+    if not isinstance(answer, (list, tuple)):
+        answer = [answer] * len(extracted_responses)
+    
     if (random.random() < 0.01) and logging:  # 1% chance to write samples into a file
         os.makedirs(
             f"model_output_samples/multi_stage_gsm8k_samples_from_{os.getenv('HOSTNAME')}",
@@ -241,9 +250,15 @@ def final_correctness_reward_func(
             f.write("-" * 20)
             out_line = f"Prompt:\n{p}\n\nAnswer:\n{answer[0]}\n\nResponse:\n{responses[0]}\n\nExtracted:\n{extracted_responses[0]}"
             f.write(out_line)
-    return [
-        1.0 * weighting if r == a else 0.0 for r, a in zip(extracted_responses, answer)
-    ]
+    
+    # Safe comparison with proper null checks
+    result = []
+    for r, a in zip(extracted_responses, answer):
+        if r is not None and a is not None:
+            result.append(1.0 * weighting if r == a else 0.0)
+        else:
+            result.append(0.0)
+    return result
 
 
 def strict_format_reward_func(

--- a/hivemind_exp/gsm8k/stage_utils.py
+++ b/hivemind_exp/gsm8k/stage_utils.py
@@ -161,6 +161,11 @@ def gsm8k_stage_data(
         rewards = defaultdict(float)
         for outputs in final_stage_outputs:
             for node_key, output in outputs.items():
+                question = output.get("question")
+                if question is None:
+                    logging.warning(f"Missing 'question' key in output: {output}")
+                    question = "<no question available>"
+                    
                 prompts = [
                     [
                         {"role": "system", "content": output["question"]},

--- a/hivemind_exp/gsm8k/stage_utils.py
+++ b/hivemind_exp/gsm8k/stage_utils.py
@@ -168,8 +168,8 @@ def gsm8k_stage_data(
                     
                 prompts = [
                     [
-                        {"role": "system", "content": output["question"]},
-                        {"role": "system", "content": output["stage3_prompt"]},
+                        {"role": "system", "content": question},
+                        {"role": "system", "content": output.get("stage3_prompt", "<no prompt available>")},
                     ],
                 ]
                 final_answer = next(iter(output["final_agent_decision"].items()))[1]


### PR DESCRIPTION
**Problem**

The training process was failing with a TypeError stating "'NoneType' object is not iterable" in the final_correctness_reward_func function. This occurred when trying to zip extracted_responses with answer when one of them was None.
_**Error Logs before fix**_
[rank0]:   File "/rl-swarm/hivemind_exp/gsm8k/stage_utils.py", line 173, in round_winners
[rank0]:     cumulative_reward_2(prompts=prompts, completions=completions, **output)
[rank0]:   File "/rl-swarm/hivemind_exp/gsm8k/stage_utils.py", line 109, in cumulative_reward_2
[rank0]:     return stage3_rewards.hivemind_cumulative_reward(node, **kwargs)
[rank0]:   File "/rl-swarm/hivemind_exp/gsm8k/stage3_rewards.py", line 339, in hivemind_cumulative_reward
[rank0]:     final_correctness = final_correctness_reward_func(
[rank0]:   File "/rl-swarm/hivemind_exp/gsm8k/stage3_rewards.py", line 245, in final_correctness_reward_func
[rank0]:     1.0 * weighting if r == a else 0.0 for r, a in zip(extracted_responses, answer)
[rank0]: TypeError: 'NoneType' object is not iterable
[rank0]:[W420 21:08:28.121446567 ProcessGroupNCCL.cpp:1250] Warning: WARNING: process group has NOT been destroyed before we destruct ProcessGroupNCCL. On normal program exit, the application should call destroy_process_group to ensure that any pending NCCL operations have finished in this process. In rare cases this process can exit before this point and block the progress of another member of the process group. This constraint has always been present, but this warning has only been added since PyTorch 2.4 (function operator()): not found
######### down trainer...
Terminated

**Solution**
I've added proper null checks and error handling to the function:
1. Check if `answer` is None or `extracted_responses` is empty before processing
2. Ensure `answer` is always an iterable (convert single values to a list)
3. Add explicit null checks when comparing values in the loop

**Benefits**
- Prevents the TypeError that was causing training to fail
-Maintains the intended behavior when valid inputs are provided

Tested and it works without raising exception errors.
@h-grieve @jcd496 




