### PR TITLE
Update README.md with corrected Discord link for VM access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Therefore, you should do these actions in the following scenarios
 
 - **Issues on VMs/VPSs?**
 
-    - **How do I access the login screen if I'm running in a VM?**: port forwarding. Add this SSH flag: `-L 3000:localhost:3000` when connecting to your VM. E.g. `gcloud compute ssh --zone "us-central1-a" [your-vm] --project [your-project] -- -L 3000:localhost:3000`. Note, some VPSs may not work with `rl-swarm`. Check the Gensyn [discord](https://discord.gg/zAJbCTk9) for up-to-date information on this.
+    - **How do I access the login screen if I'm running in a VM?**: port forwarding. Add this SSH flag: `-L 3000:localhost:3000` when connecting to your VM. E.g. `gcloud compute ssh --zone "us-central1-a" [your-vm] --project [your-project] -- -L 3000:localhost:3000`. Note, some VPSs may not work with `rl-swarm`. Check the Gensyn [discord](https://discord.com/invite/bgyDTy39jZ) for up-to-date information on this.
     
     - **Disconnection/general issues**: If you are tunneling to a VM and suffer a broken pipe, you will likely encounter OOM or unexepected behaviour the first time you relaunch the script. If you `control + c` and kill the script it should spin down all background processes. Restart the script and everything should work normally.
 


### PR DESCRIPTION
This PR updates the Discord invitation link in the README.md troubleshooting section. The previous link was flagged as spam, while this PR provides the correct and verified Gensyn Discord invitation URL.
The updated link ensures users can access proper support channels when experiencing issues with RL-Swarm on VMs/VPSs.