### PR TITLE
Add user input for max_steps with default option and dynamic config updates

### DIFF
--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -119,6 +119,17 @@ while true; do
     esac
 done
 
+while true; do
+    echo -en $GREEN_TEXT
+    read -p ">> How many max_steps would you like to use? [1000, 5000, 10000, 50000, 100000] " steps
+    echo -en $RESET_TEXT
+    steps=${steps:-20}  # Default to "20" if the user presses Enter
+    case $steps in
+        5 | 20 | 50 | 100 | 200 | 500 | 1000 | 2000) MAX_STEPS=$steps && break ;;
+        *)  echo ">>> Please answer in [5, 20, 50, 100, 200, 500, 1000, 2000]." ;;
+    esac
+done
+
 if [ "$CONNECT_TO_TESTNET" = true ]; then
     # Run modal_login server.
     echo "Please login to create an Ethereum Server Wallet"

--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -253,6 +253,15 @@ else
     esac
 fi
 
+echo_green ">> Setting max_steps=$MAX_STEPS in config: $CONFIG_PATH"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/^max_steps: .*/max_steps: $MAX_STEPS/" "$CONFIG_PATH"
+else
+    sed -i "s/^max_steps: .*/max_steps: $MAX_STEPS/" "$CONFIG_PATH"
+fi
+
+
 echo_green ">> Good luck in the swarm!"
 echo_blue ">> Post about rl-swarm on X/twitter! --> https://tinyurl.com/swarmtweet"
 echo_blue ">> And remember to star the repo on GitHub! --> https://github.com/gensyn-ai/rl-swarm"

--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -121,7 +121,7 @@ done
 
 while true; do
     echo -en $GREEN_TEXT
-    read -p ">> How many max_steps would you like to use? [1000, 5000, 10000, 50000, 100000] " steps
+    read -p ">> How many max_steps would you like to use? [5, 20, 50, 100, 200, 500, 1000, 2000] " steps
     echo -en $RESET_TEXT
     steps=${steps:-20}  # Default to "20" if the user presses Enter
     case $steps in

--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -121,13 +121,18 @@ done
 
 while true; do
     echo -en $GREEN_TEXT
-    read -p ">> How many max_steps would you like to use? [5, 20, 50, 100, 200, 500, 1000, 2000] " steps
+    read -p ">> How many max_steps would you like to use? (Enter a positive integer or press Enter for the default of 20) " steps
     echo -en $RESET_TEXT
-    steps=${steps:-20}  # Default to "20" if the user presses Enter
-    case $steps in
-        5 | 20 | 50 | 100 | 200 | 500 | 1000 | 2000) MAX_STEPS=$steps && break ;;
-        *)  echo ">>> Please answer in [5, 20, 50, 100, 200, 500, 1000, 2000]." ;;
-    esac
+    # Use default value of 20 if the user presses Enter
+    steps=${steps:-20}
+    # Check if the input is a positive integer
+    if [[ $steps =~ ^[1-9][0-9]*$ ]]; then
+        MAX_STEPS=$steps
+        echo ">> You have selected $MAX_STEPS steps."
+        break
+    else
+        echo ">>> Please enter a valid positive integer or press Enter for the default of 20."
+    fi
 done
 
 if [ "$CONNECT_TO_TESTNET" = true ]; then


### PR DESCRIPTION
### Summary
This pull request introduces the following enhancements to the `rl-swarm` framework:

1. **User Input for `max_steps`**:
   - Added a prompt allowing users to specify the number of `max_steps` for their configuration.
   - Users can now input any positive integer or press Enter to use the default value of 20 steps.
   - Ensured user input is validated to only accept positive integers.

2. **Dynamic Update of Configuration File**:
   - The chosen `max_steps` value is dynamically written into the selected configuration file (`$CONFIG_PATH`).
   - Utilized `sed` to replace the `max_steps` value in the YAML configuration, ensuring consistency between user input and the config file.

3. **Improved Script Usability**:
   - Enhanced user prompts for clarity and flexibility.
   - Maintained the logical flow of parameter selection, making it intuitive for users.

### How It Works
- The script now prompts the user for `max_steps` after parameter selection (`PARAM_B`).
- If the user presses Enter, the default value of 20 steps is used.
- The selected value is validated and then updated in the relevant configuration file.

### Testing
- Local tested and verified that the `max_steps` input is correctly handled and default values are applied when no input is provided.
- Confirmed that the configuration file is dynamically updated with the selected `max_steps` value.

### Notes
These changes enhance the flexibility and usability of the `rl-swarm` framework, making it easier for users to customize their training configurations.

Let me know if further adjustments are needed!