### PR TITLE
Set max allowed transformers version to 4.51.3

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -4,6 +4,6 @@ hivemind @ git+https://github.com/learning-at-home/hivemind@1.11.11
 hf-transfer
 peft
 tensorboard
-transformers>=4.46.0
+transformers>=4.46.0,<=4.51.3
 trl
 web3

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -6,7 +6,7 @@ hf-transfer
 peft
 tensorboard
 torch
-transformers>=4.46.0
+transformers>=4.46.0,<=4.51.3
 trl
 unsloth @ git+https://github.com/gensyn-ai/unsloth@unpin_proto
 unsloth_zoo @ git+https://github.com/gensyn-ai/unsloth-zoo@unpin_proto


### PR DESCRIPTION
This PR fixes #310 #314 #304 

I verified 4.51.3 version cap fixes both issues. Also, here is my `pip list | grep transformers` after the update:

```bash
@haritowa ➜ /workspaces/rl-swarm (main) $ pip list | grep transformers
transformers                      4.51.3
```