### PR TITLE
FIX: await isn't allowed in non-async function

### DIFF
--- a/modal-login/app/layout.tsx
+++ b/modal-login/app/layout.tsx
@@ -13,16 +13,17 @@ export const metadata: Metadata = {
   description: "Modal sign in for Gensyn Testnet",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   // Persist state across pages
   // https://accountkit.alchemy.com/react/ssr#persisting-the-account-state
+  const headerList = await headers();
   const initialState = cookieToInitialState(
     config,
-    headers().get("cookie") ?? undefined,
+    headerList.get("cookie") ?? undefined,
   );
 
   return (


### PR DESCRIPTION
Failed to compile.

./app/layout.tsx
Error:   x await isn't allowed in non-async function
    ,-[/home/ubuntu/rl-swarm/modal-login/app/layout.tsx:27:1]
 24 |     config,
 25 |     headers().get("cookie") ?? undefined,
 26 |   );*/
 27 | const headerList = await headers();
    :                    ^^^^^
 28 | const initialState = cookieToInitialState(
 29 |   config,
 30 |   headerList.get("cookie") ?? undefined,
    `----

Caused by:
    Syntax Error

Import trace for requested module:
./app/layout.tsx