### PR TITLE
Update layout.tsx

### DIFF
--- a/modal-login/app/layout.tsx
+++ b/modal-login/app/layout.tsx
@@ -13,17 +13,15 @@ export const metadata: Metadata = {
   description: "Modal sign in for Gensyn Testnet",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Persist state across pages
-  // https://accountkit.alchemy.com/react/ssr#persisting-the-account-state
-  const initialState = cookieToInitialState(
-    config,
-    headers().get("cookie") ?? undefined,
-  );
+  const headerValues = await headers();
+  const cookie = headerValues.get("cookie") ?? undefined;
+
+  const initialState = cookieToInitialState(config, cookie);
 
   return (
     <html lang="en">


### PR DESCRIPTION
Problem
While setting up the Gensyn testnet node, I encountered a build failure caused by a TypeScript error in the layout.tsx file:

Type error: Property 'get' does not exist on type 'Promise<ReadonlyHeaders>'

The error is thrown due to the following line in app/layout.tsx:

const initialState = cookieToInitialState(
  config,
  headers().get("cookie") ?? undefined
);

The headers() function from Next.js returns a Promise<ReadonlyHeaders>, so calling .get(...) directly on it without awaiting the promise causes a type error.

Solution
To fix the issue, the function containing this logic must be marked async, and the headers should be properly awaited before use.

After applying this fix, the build completes successfully and the Gensyn modal login page works as expected.