### PR TITLE
Fix: TypeError in layout.tsx due to missing await on async headers() (breaks run_rl_swarm.sh)

### DIFF
--- a/modal-login/app/layout.tsx
+++ b/modal-login/app/layout.tsx
@@ -13,16 +13,17 @@ export const metadata: Metadata = {
   description: "Modal sign in for Gensyn Testnet",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Persist state across pages
-  // https://accountkit.alchemy.com/react/ssr#persisting-the-account-state
+  // Wait a headers
+  const headerData = await headers();
+
   const initialState = cookieToInitialState(
     config,
-    headers().get("cookie") ?? undefined,
+    headerData.get("cookie") ?? undefined,
   );
 
   return (


### PR DESCRIPTION
This pull request fixes a TypeScript error in `modal-login/app/layout.tsx` that prevents the project from building successfully.

### 🔥 Problem

When executing `./run_rl_swarm.sh`, the following error is thrown during the server build phase (captured in `yarn.log`):

```
./app/layout.tsx:25:15
Type error: Property 'get' does not exist on type 'Promise<ReadonlyHeaders>'.

  23 |   const initialState = cookieToInitialState(
  24 |     config,
> 25 |     headers().get("cookie") ?? undefined,
     |               ^
  26 |   );
  27 |
  28 |   return (
Next.js build worker exited with code: 1 and signal: null
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This is caused by an attempt to access `.get("cookie")` on a Promise instead of the resolved `headers()` object. The root function (`RootLayout`) was not declared `async`, so the `await` was missing when calling `headers()`.

### ✅ Fix

- Converted `RootLayout` to `async`
- Added `await headers()` before reading cookie data

### ✅ Result

This fix resolves the TypeScript error and allows `run_rl_swarm.sh` to complete the build without crashing.

Let me know if you'd like me to adjust anything. Happy to iterate!