### PR TITLE
Add a volume for ~/.cache to containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
       - ./user/keys:/home/gensyn/rl_swarm/keys
       - ./user/configs:/home/gensyn/rl_swarm/configs
       - ./user/logs:/home/gensyn/rl_swarm/logs
+      - ./user/cache:/home/gensyn/.cache
     environment:
       - HF_TOKEN=${HF_TOKEN}
       - GENSYN_RESET_CONFIG=${GENSYN_RESET_CONFIG}
@@ -63,6 +64,7 @@ services:
       - ./user/keys:/home/gensyn/rl_swarm/keys
       - ./user/configs:/home/gensyn/rl_swarm/configs
       - ./user/logs:/home/gensyn/rl_swarm/logs
+      - ./user/cache:/home/gensyn/.cache
     environment:
       - HF_TOKEN=${HF_TOKEN}
       - GENSYN_RESET_CONFIG=${GENSYN_RESET_CONFIG}

--- a/run_rl_swarm.sh
+++ b/run_rl_swarm.sh
@@ -31,6 +31,7 @@ if [ -n "$DOCKER" ]; then
         /home/gensyn/rl_swarm/keys
         /home/gensyn/rl_swarm/configs
         /home/gensyn/rl_swarm/logs
+        /home/gensyn/.cache
     )
 
     for volume in ${volumes[@]}; do


### PR DESCRIPTION
Map user/cache to /home/gensyn/.cache so that the container doesn't need to download GBs of data every time it restarts