### PR TITLE
feat(config): make login port dynamic to avoid conflicts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       args:
         - BASE_IMAGE=ubuntu:24.04
     ports:
-      - 3000:3000
+      - "${LOGIN_PORT:-3000}:${LOGIN_PORT:-3000}"
     volumes:
       - ./user/modal-login:/home/gensyn/rl_swarm/modal-login/temp-data
       - ./user/keys:/home/gensyn/rl_swarm/keys
@@ -43,6 +43,7 @@ services:
     environment:
       - HF_TOKEN=${HF_TOKEN}
       - GENSYN_RESET_CONFIG=${GENSYN_RESET_CONFIG}
+      - LOGIN_PORT=${LOGIN_PORT:-3000}
 
   # Requires the NVIDIA Drivers version >=525.60.13 to be installed, as well
   # as the nvidia-container-toolkit.
@@ -57,7 +58,7 @@ services:
       args:
         - BASE_IMAGE=nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04
     ports:
-      - 3000:3000
+      - "${LOGIN_PORT:-3000}:${LOGIN_PORT:-3000}"
     volumes:
       - ./user/modal-login:/home/gensyn/rl_swarm/modal-login/temp-data
       - ./user/keys:/home/gensyn/rl_swarm/keys
@@ -66,6 +67,7 @@ services:
     environment:
       - HF_TOKEN=${HF_TOKEN}
       - GENSYN_RESET_CONFIG=${GENSYN_RESET_CONFIG}
+      - LOGIN_PORT=${LOGIN_PORT:-3000}
     deploy:
       resources:
         reservations:

--- a/rgym_exp/config/rg-swarm.yaml
+++ b/rgym_exp/config/rg-swarm.yaml
@@ -14,7 +14,7 @@ blockchain:
   contract_address: ${oc.env:SWARM_CONTRACT,null} # This is set by modal-login in run_rl_swarm.sh
   org_id: ${oc.env:ORG_ID,null} # This is set by modal-login in run_rl_swarm.sh
   mainnet_chain_id: 685685 # currently unused, will be used with WalletSwarmCoordinator
-  modal_proxy_url: "http://localhost:3000/api/"
+  modal_proxy_url: "http://localhost:${oc.env:LOGIN_PORT,3000}/api/"
 
 communications:
   initial_peers:


### PR DESCRIPTION
The startup script now finds an available port for the login server, starting from 3000, instead of using a hardcoded value.

This prevents startup failures when the default port is already in use. The dynamically chosen port is then used by the modal-login server, passed as an environment variable to the docker container, and used in the application's configuration file.