### PR TITLE
fix: add --network-timeout option to yarn install for improved reliability

### DIFF
--- a/containerfiles/swarm-node/swarm.containerfile
+++ b/containerfiles/swarm-node/swarm.containerfile
@@ -51,7 +51,7 @@ RUN ./install_pip.sh
 ENV PATH="/home/gensyn/.pyenv/shims:/home/gensyn/.pyenv/bin:$NVM_DIR/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
 COPY --chown=gensyn ./modal-login /home/gensyn/rl_swarm/modal-login
-RUN cd /home/gensyn/rl_swarm/modal-login && yarn install --immutable && yarn build
+RUN cd /home/gensyn/rl_swarm/modal-login && yarn install --immutable --network-timeout 100000 && yarn build
 
 RUN pip install gensyn-genrl==0.1.4
 RUN pip install reasoning-gym>=0.1.20 # for reasoning gym env


### PR DESCRIPTION

<img width="1715" height="562" alt="Screenshot_1551" src="https://github.com/user-attachments/assets/adc8aad6-2126-44a2-8925-ac2391d0afc3" />


### Summary

This PR adds the `--network-timeout 100000` flag to the `yarn install` command to improve reliability during dependency installation. This change helps avoid timeout issues in environments with slow or unstable network connections.

### Changes Made

- Updated `swarm.containerfile` to include `--network-timeout 100000` in the `yarn install` command.

### Reason

In certain environments (e.g. CI/CD or behind slow proxies), the default timeout for `yarn` may cause installation to fail. Increasing the timeout ensures a more stable install process.

### Notes

- No changes to application logic or runtime behavior.
- Safe, minor change focused on improving developer experience.

--- Thanks 

