### PR TITLE
Fix PRG state backup type issues (#460)

### DIFF
--- a/rgym_exp/src/prg_module.py
+++ b/rgym_exp/src/prg_module.py
@@ -53,7 +53,7 @@ class PRGModule:
         if os.path.exists(self.prg_state_file):
             with open(self.prg_state_file, 'r') as f:
                 state = json.load(f)
-                self._prg_history_dict = state['prg_history_dict']
+                self._prg_history_dict = {int(k): v for k, v in state['prg_history_dict'].items()}
                 self.prg_last_game_claimed = state['prg_last_game_claimed']
                 self.prg_last_game_played = state['prg_last_game_played']
             get_logger().info(


### PR DESCRIPTION
I guess you haven't noticed that saving the PRG game state doesn't work correctly. FYI: JSON does not support integer keys, but Python dictionaries do! This causes problems because on the first cycle (on boot) you are looking for an integer API response keys in the deserialized PRG state, which only contains string keys. Because of this, every node restart forces it to make another bet.