### PR TITLE
Fix incorrect model names in README.md (CodeZero)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ RL Swarm is a peer-to-peer system for reinforcement learning. It allows you to t
 > CodeZero extends RL Swarm beyond reasoning and math into **coding tasks**, where models take on distinct roles, *Solvers*, *Proposers*, and *Evaluators*, to enable **collaborative learning** across a decentralized network.
 
 Models (CodeZero):
-   - **Qwen2.5-Coder-0.5B-Instruct** — Solver role  
-   - **Qwen2.5-Coder-1.5B-Instruct** — Evaluator (frozen)  
+   - **Qwen/Qwen2.5-Coder-0.5B-Instruct** — Solver role  
+   - **Qwen/Qwen2.5-Coder-1.5B-Instruct** — Evaluator (frozen)  
 
 Currently, we are running **CodeZero** on the Gensyn Testnet.  
 


### PR DESCRIPTION
Fixed model names to include Qwen/ prefix:

- Qwen2.5-Coder-0.5B-Instruct → Qwen/Qwen2.5-Coder-0.5B-Instruct (Solver role)
- Qwen2.5-Coder-1.5B-Instruct → Qwen/Qwen2.5-Coder-1.5B-Instruct (Evaluator - frozen)

This matches the correct Hugging Face repository format and prevents model loading errors.

@sirbonneville Could you please check it?