### PR TITLE
Reduce hivemind log noise 

### DIFF
--- a/code_gen_exp/runner/swarm_launcher.py
+++ b/code_gen_exp/runner/swarm_launcher.py
@@ -15,6 +15,7 @@ from code_gen_exp.src.utils.omega_gpu_resolver import (
 
 import logging
 logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("hivemind").setLevel(logging.CRITICAL)
 
 @hydra.main(version_base=None)
 def main(cfg: DictConfig):


### PR DESCRIPTION
** Set hivemind library log level to CRITICAL to suppress tracebacks during connection failures while maintaining normal operation.

### Before
Multi-line ERROR tracebacks clutter logs during p2p connection attempts:
- ConnectionRefusedError: [Errno 111] Connection refused with full traceback
- Difficult to read actual training progress

<img width="1280" height="569" alt="image" src="https://github.com/user-attachments/assets/6121b665-ae02-4335-9ae7-b117c765515f" />


### After  
Clean, concise error handling log:
- Single-line graceful error message
- Training continues normally with local state fallback

<img width="1911" height="430" alt="image" src="https://github.com/user-attachments/assets/e7266efc-78a8-4d8a-8e52-8d7a114711dc" />


@jcd496 can you look into this once?




