### PR TITLE
Change python command to python3 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you previously ran RL Swarm during the reasoning-gym phase, your node will au
 ```sh
 git pull
 rm -rf .venv
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 ```
 
@@ -84,7 +84,7 @@ Existing nodes running the previous "reasoning-gym" Swarm can continue operating
   ```sh
   git pull
   rm -rf .venv
-  python -m venv .venv
+  python3 -m venv .venv
   source .venv/bin/activate
   ```
 
@@ -107,7 +107,7 @@ git clone https://github.com/gensyn-ai/rl-swarm
 ```sh
 git pull
 rm -rf .venv
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 ```
 
@@ -209,7 +209,7 @@ Users will run **Solver** nodes.
   ```sh
   git pull
   rm -rf .venv
-  python -m venv .venv
+  python3 -m venv .venv
   source .venv/bin/activate
   ```
 


### PR DESCRIPTION
Updated commands to use python3 for creating virtual environments. In Ubuntu 22.04 and above minimum python version is 3.10 and above.